### PR TITLE
added forgot password option

### DIFF
--- a/auth.css
+++ b/auth.css
@@ -155,6 +155,20 @@ p{
   animation: authFadeUp 560ms cubic-bezier(0.22,1,0.36,1) 500ms forwards;
 }
 
+.auth-inline-link{
+  margin-top:10px;
+  margin-bottom:6px;
+  font-size:14px;
+  animation-delay:460ms;
+}
+
+.auth-message{
+  margin-top:10px;
+  color:#4d8f67;
+  font-size:14px;
+  min-height:20px;
+}
+
 a{
   color:#ff86ba;
   font-weight:600;

--- a/auth.js
+++ b/auth.js
@@ -6,6 +6,7 @@ function getMainPagePath(fileName) {
 
 const USER_STORAGE_KEY = "user";
 const AUTH_SESSION_KEY = "authSession";
+const PASSWORD_RESET_EMAIL_KEY = "passwordResetEmail";
 const SESSION_DURATION_MS = 2 * 60 * 60 * 1000;
 const HASH_ITERATIONS = 120000;
 
@@ -76,6 +77,18 @@ function getStoredUser() {
 
 function storeUser(userRecord) {
   localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(userRecord));
+}
+
+function setPasswordResetEmail(email) {
+  localStorage.setItem(PASSWORD_RESET_EMAIL_KEY, normalizeEmail(email));
+}
+
+function getPasswordResetEmail() {
+  return normalizeEmail(localStorage.getItem(PASSWORD_RESET_EMAIL_KEY));
+}
+
+function clearPasswordResetEmail() {
+  localStorage.removeItem(PASSWORD_RESET_EMAIL_KEY);
 }
 
 async function derivePasswordHash(password, saltBytes, iterations) {
@@ -311,6 +324,106 @@ if (signinForm) {
       error.textContent = "Invalid email or password";
     } catch (_error) {
       error.textContent = "Login failed. Please try again.";
+    }
+  });
+}
+
+/* Forgot password */
+const forgotPasswordForm = document.getElementById("forgotPasswordForm");
+
+if (forgotPasswordForm) {
+  forgotPasswordForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const email = normalizeEmail(document.getElementById("resetEmail").value);
+    const error = document.getElementById("forgotError");
+    const success = document.getElementById("forgotSuccess");
+    const resetLinkArea = document.getElementById("resetLinkArea");
+    const storedUser = getStoredUser();
+
+    error.textContent = "";
+    success.textContent = "";
+    resetLinkArea.hidden = true;
+
+    if (!isValidEmail(email)) {
+      error.textContent = "Please enter a valid email address.";
+      return;
+    }
+
+    if (!storedUser || normalizeEmail(storedUser.email) !== email) {
+      error.textContent = "Email not found!";
+      clearPasswordResetEmail();
+      return;
+    }
+
+    setPasswordResetEmail(email);
+    success.textContent = "Reset link generated (demo). Click the link below to continue.";
+    resetLinkArea.hidden = false;
+  });
+}
+
+/* Reset password */
+const resetPasswordForm = document.getElementById("resetPasswordForm");
+
+if (resetPasswordForm) {
+  resetPasswordForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const newPassword = document.getElementById("newPassword").value;
+    const confirmNewPassword = document.getElementById("confirmNewPassword").value;
+    const error = document.getElementById("resetError");
+    const success = document.getElementById("resetSuccess");
+
+    error.textContent = "";
+    success.textContent = "";
+
+    const resetEmail = getPasswordResetEmail();
+    if (!resetEmail) {
+      error.textContent = "Reset session expired. Start from Forgot Password again.";
+      return;
+    }
+
+    const passwordMessage = validatePasswordStrength(newPassword);
+    if (passwordMessage) {
+      error.textContent = passwordMessage;
+      return;
+    }
+
+    if (newPassword !== confirmNewPassword) {
+      error.textContent = "Passwords do not match!";
+      return;
+    }
+
+    const storedUser = getStoredUser();
+    if (!storedUser || normalizeEmail(storedUser.email) !== resetEmail) {
+      error.textContent = "No matching user found for password reset.";
+      clearPasswordResetEmail();
+      return;
+    }
+
+    try {
+      const hashed = await hashPassword(newPassword);
+      const updatedUser = {
+        ...storedUser,
+        version: 2,
+        email: resetEmail,
+        passwordHash: hashed.hash,
+        salt: hashed.salt,
+        iterations: hashed.iterations,
+        updatedAt: new Date().toISOString(),
+      };
+      delete updatedUser.password;
+
+      storeUser(updatedUser);
+      clearPasswordResetEmail();
+      clearSession();
+      success.textContent = "Password updated successfully. Redirecting to Sign In...";
+
+      setTimeout(() => {
+        window.location.href = getMainPagePath("signin.html");
+      }, 1200);
+    } catch (_error) {
+      error.textContent = "Unable to reset password right now. Please try again.";
     }
   });
 }

--- a/forgot.html
+++ b/forgot.html
@@ -4,38 +4,33 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https:; font-src 'self' data: https://cdnjs.cloudflare.com; media-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests">
-  <title>Sign In</title>
+  <title>Forgot Password</title>
   <link rel="stylesheet" href="auth.css">
 </head>
 
 <body class="auth-page">
   <div class="auth-container">
-    <form id="signinForm">
-      <h2>Login</h2>
+    <form id="forgotPasswordForm">
+      <h2>Forgot Password</h2>
 
       <div class="input-group">
-        <input type="email" id="loginEmail" placeholder="Email" required>
+        <input type="email" id="resetEmail" placeholder="Enter your email" required>
       </div>
 
-      <div class="input-group">
-        <input type="password" id="loginPassword" placeholder="Password" required>
-        <span class="toggle-password" onclick="togglePassword('loginPassword', this)">&#128065;</span>
-      </div>
+      <div class="error" id="forgotError"></div>
+      <div class="auth-message" id="forgotSuccess"></div>
 
-      <div class="error" id="loginError"></div>
+      <button type="submit">Generate Reset Link</button>
 
-      <p class="auth-inline-link"><a href="forgot.html">Forgot Password?</a></p>
+      <p id="resetLinkArea" class="auth-message" hidden>
+        Reset link ready:
+        <a href="reset.html">Reset Password</a>
+      </p>
 
-      <button type="submit">Sign In</button>
-      <p>Don't have an account? <a href="signup.html">Sign Up</a></p>
+      <p>Remembered your password? <a href="signin.html">Back to Sign In</a></p>
     </form>
   </div>
 
   <script src="auth.js"></script>
-  <script>
-    if (hasActiveSession()) {
-      window.location.href = "index.html";
-    }
-  </script>
 </body>
 </html>

--- a/reset.html
+++ b/reset.html
@@ -4,38 +4,33 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https:; font-src 'self' data: https://cdnjs.cloudflare.com; media-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; upgrade-insecure-requests">
-  <title>Sign In</title>
+  <title>Reset Password</title>
   <link rel="stylesheet" href="auth.css">
 </head>
 
 <body class="auth-page">
   <div class="auth-container">
-    <form id="signinForm">
-      <h2>Login</h2>
+    <form id="resetPasswordForm">
+      <h2>Reset Password</h2>
 
       <div class="input-group">
-        <input type="email" id="loginEmail" placeholder="Email" required>
+        <input type="password" id="newPassword" placeholder="New Password" required>
+        <span class="toggle-password" onclick="togglePassword('newPassword', this)">&#128065;</span>
       </div>
 
       <div class="input-group">
-        <input type="password" id="loginPassword" placeholder="Password" required>
-        <span class="toggle-password" onclick="togglePassword('loginPassword', this)">&#128065;</span>
+        <input type="password" id="confirmNewPassword" placeholder="Confirm New Password" required>
+        <span class="toggle-password" onclick="togglePassword('confirmNewPassword', this)">&#128065;</span>
       </div>
 
-      <div class="error" id="loginError"></div>
+      <div class="error" id="resetError"></div>
+      <div class="auth-message" id="resetSuccess"></div>
 
-      <p class="auth-inline-link"><a href="forgot.html">Forgot Password?</a></p>
-
-      <button type="submit">Sign In</button>
-      <p>Don't have an account? <a href="signup.html">Sign Up</a></p>
+      <button type="submit">Update Password</button>
+      <p><a href="signin.html">Back to Sign In</a></p>
     </form>
   </div>
 
   <script src="auth.js"></script>
-  <script>
-    if (hasActiveSession()) {
-      window.location.href = "index.html";
-    }
-  </script>
 </body>
 </html>


### PR DESCRIPTION


Updated files:
- Added forgot link on sign-in page: signin.html
- Added forgot-password screen: forgot.html
- Added reset-password screen: reset.html
- Added forgot/reset logic with localStorage and secure password re-hash: auth.js
- Added small UI styles for inline link and status messages: auth.css

What the new flow does:
1. User clicks Forgot Password on signin.html.
2. On forgot.html, user enters email.
3. If email matches the stored user, a simulated reset link is shown (demo behavior), and reset email is stored in localStorage.
4. On reset.html, user enters new password + confirm password.
5. Password is validated with the same strength rules, then updated in localStorage using the existing hash flow (PBKDF2), and user is redirected to sign in.

Implementation notes:
- Kept compatibility with your existing secure auth model in auth.js, instead of introducing plain-text password storage.
- Reset state uses a dedicated localStorage key: passwordResetEmail.
- Legacy plain-text password field is removed when password reset completes.

Validation:
- No new JS/HTML errors were reported.
- Existing CSS Safari compatibility warnings for backdrop-filter remain in auth.css and auth.css (pre-existing, not from this feature).


<img width="335" height="334" alt="Screenshot 2026-03-23 183901" src="https://github.com/user-attachments/assets/ce80fa4c-a729-4db8-9185-43bce5bb381f" />

closes #55